### PR TITLE
Updated Guide Authors Section with their respective profile

### DIFF
--- a/_guide-pages/how-to-set-reminders-in-slack.md
+++ b/_guide-pages/how-to-set-reminders-in-slack.md
@@ -3,51 +3,65 @@ layout: guide-pages
 title: How to Set Reminders in Slack
 provider-link: "/how-to-set-reminders-in-slack"
 overview: "Slack is a communication and collaboration platform that organizes conversations into topics, groups or private messages.  Each topic or group is called a Channel.  Hack for LA uses slack to allow teams to connect, discuss and work on projects collectively.  There are channels set up for both specific projects, and specific functional roles."
-sections:
-  - title: "What is Slack?"
-    href: "#what-is-slack"
-  - title: "When to use Reminders"
-    href: "#when-to-use-reminders"
-    subsection:
-      - title: "Who uses reminders"
-        href: "#who-uses-reminders"
-      - title: "Type of Reminders"
-        href: "#type-of-reminders"
-  - title: "How to Set Up Reminders?"
-    href: "#how-to-set-up-reminders-"
-    subsection:
-      - title: "Option 1: by Navigation"
-        href: "#option-1-by-navigation"
-      - title: "Option 2: by Direct Entry"
-        href: "#option-2-by-direct-entry"
-  - title: "When to use Reminders"
-    href: "#when-to-use-reminders"
-  - title: "Examples"
-    href: "#examples"
-  - title: "Guide Authors"
-    href: "#guide-authors"
+# sections:
+#   - title: "What is Slack?"
+#     href: "#what-is-slack"
+#   - title: "When to use Reminders"
+#     href: "#when-to-use-reminders"
+#     subsection:
+#       - title: "Who uses reminders"
+#         href: "#who-uses-reminders"
+#       - title: "Type of Reminders"
+#         href: "#type-of-reminders"
+#   - title: "How to Set Up Reminders?"
+#     href: "#how-to-set-up-reminders-"
+#     subsection:
+#       - title: "Option 1: by Navigation"
+#         href: "#option-1-by-navigation"
+#       - title: "Option 2: by Direct Entry"
+#         href: "#option-2-by-direct-entry"
+#   - title: "When to use Reminders"
+#     href: "#when-to-use-reminders"
+#   - title: "Examples"
+#     href: "#examples"
+#   - title: "Guide Authors"
+#     href: "#guide-authors"
 guide-author:
   - name: "Maria Studnicka"
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/maria-studnicka/"
+      github: "https://github.com/mariastudnicka"
+    picture: https://avatars.githubusercontent.com/mariastudnicka
   - name: "Katie Jensen" 
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/katie-jensen/"
+      github:
+    picture: https://media-exp1.licdn.com/dms/image/C4E03AQFxH7i2p-BbAQ/profile-displayphoto-shrink_400_400/0/1623178954400?e=1650499200&v=beta&t=7JZ76Ux55xt-UhcvTWODpcMDYcP1v9nHa6Pymi9Hae4
   - name: "Saasha Gilkes"
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
-  - name: "Oliva Chiong"
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/saashagilkes/"
+      github: "https://github.com/SaashaG"
+    picture: https://avatars.githubusercontent.com/SaashaG
+  - name: "Olivia Chiong"
+    links:
+      linked-in: "https://www.linkedin.com/in/chiongolivia/"
+      github: "https://github.com/Olivia-Chiong"
+    picture: https://avatars.githubusercontent.com/Olivia-Chiong
   - name: "Alyssa Benipayo"
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/alyssabenipayo/"
+      github: "https://github.com/alyssabenipayo"
+    picture: https://avatars.githubusercontent.com/alyssabenipayo    
   - name: "Bukola Ogunleye"
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/bukola-ogunleye-j/"
+      github: "https://github.com/SheIsBukki"
+    picture: https://avatars.githubusercontent.com/SheIsBukki   
   - name: "Bonnie Wolfe" 
-    linked-in: "https://www.linkedin.com/"
-    github: "https://github.com/"
+    links:
+      linked-in: "https://www.linkedin.com/in/bonnieawolfe/"
+      github: "https://github.com/ExperimentsInHonesty"
+    picture: https://avatars.githubusercontent.com/ExperimentsInHonesty   
 ---
 
 # **What** is Slack?

--- a/_layouts/guide-pages.html
+++ b/_layouts/guide-pages.html
@@ -8,7 +8,7 @@ layout: default
     
     <div class="page-content-container-grid">   
       <div class="card-primary page-card--guide page-card--overview">
-        <!-- This page card contains the guide's overview and direct links -->
+        <!-- This page card contains the guide"s overview and direct links -->
         <h1 class="guide-title">{{ page.title }}</h1>
         {{ page.overview | markdownify }}
         
@@ -43,10 +43,32 @@ layout: default
       <h1>Guide Authors</h1>
       <p>Peer-created guides are an important part of Hack for LA's Culture.  They are created by our Volunteer Members based on effective processes developed on our projects.</p>
       <p>This guide was created and contributed to by:</p>
-      
-      <p><b>Help us make this guide better:</b></p>
 
-      
+      <div class="authors-container">
+          {% for item in page.guide-author %}
+          <div class="authors-profile">
+            {% if item.links.github %}
+            <a href="{{ item.links.github }}" target="_blank" title="{{ item.name }}'s GitHub Profile"><img class="author-img" src="{{ item.picture }}" width="100" height="100"/></a>
+            <!-- <img src="{{ item.picture }}" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            {% else %}
+            <a href="{{ item.links.linked-in }}" target="_blank" title="{{ item.name }}'s LinkedIn Profile"><div class="author-img-placeholder"></div></a>
+            {% endif %}
+            <p>{{ item.name }}</p>
+          </div>
+          <div class="authors-contact">
+          {% if item.links.linked-in and item.links.github %}
+          <a href="{{ item.links.linked-in }}" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="{{ item.links.github }}" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          {% elsif item.links.linked-in %}
+          <a href="{{ item.links.linked-in }}" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          {% else %}
+          <a href="{{ item.links.github }}" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+
+      <p><b>Help us make this guide better:</b></p>
       <p>If you are a member of the Hack for LA community you can post any comments directly in the iterative version of this guide: <a href="https://www.google.com/"style="color: #fa114f;" >{{page.title}}</a>.</p>
 
       <p>If you are outside the Hack for LA community, please use this feedback form to provide suggestions for improvement or how the guide is useful for you.</p>
@@ -97,5 +119,5 @@ layout: default
   <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
   
   <!-- Include javaScript -->
-  <script src="{{ '/assets/js/guidepages.js' | absolute_url }}"></script>  
+  <script src="{{ "/assets/js/guidepages.js" | absolute_url }}"></script>  
   

--- a/_site/css/style.css
+++ b/_site/css/style.css
@@ -59,16 +59,17 @@ body {
 
 .page-content-container-grid {
 	display: grid;
-	grid-template-columns: auto;
+	grid-template-columns: 20vw auto;
 	grid-template-rows: auto;
 	grid-template-areas:
-		"content1 nav1"
-		"content2 nav2"
-		"content3 nav3"
-		"content4 nav4";
+		"content1 nav"
+		"content2 ......."
+		"content3 ......."
+		"content4 .......";
 	justify-content: start;
 	scroll-behavior: smooth;
 	align-items: start;
+	grid-column-start: 1;
 }
 
 .card-primary.page-card--guide.page-card--overview {
@@ -94,8 +95,45 @@ body {
 	grid-area: content2;
 }
 
+/* Guide Authors */
+
 .page-card--authors {
 	grid-area: content3;
+}
+
+.authors-container {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-gap: 20px;
+	margin-bottom: 32px;
+	margin-top: 20px;
+}
+
+.authors-profile {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.authors-profile > a {
+	margin-right: 28px;
+}
+
+.authors-profile img {
+	border-radius: 50%;
+}
+
+.authors-contact {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.author-img-placeholder {
+	background-color: #efefef;
+	width: 100px;
+	height: 100px;
+	border-radius: 50%;
 }
 
 .card-primary {
@@ -127,7 +165,8 @@ body {
 }
 
 .sticky-nav {
-	grid-area: nav2;
+	grid-area: nav;
+	grid-column-start: 2;
 	display: none;
 	background: #fff;
 	border: 0px solid rgba(51, 51, 51, 0.06);
@@ -255,7 +294,6 @@ img {
 
 	.page-content-container-grid {
 		margin-left: 100px;
-		grid-area: content;
 		justify-self: start;
 		grid-template-columns: 996px auto;
 		grid-template-rows: auto;

--- a/_site/guide-pages/how-to-set-reminders-in-slack.html
+++ b/_site/guide-pages/how-to-set-reminders-in-slack.html
@@ -36,58 +36,13 @@
     
     <div class="page-content-container-grid">   
       <div class="card-primary page-card--guide page-card--overview">
-        <!-- This page card contains the guide's overview and direct links -->
+        <!-- This page card contains the guide"s overview and direct links -->
         <h1 class="guide-title">How to Set Reminders in Slack</h1>
         <p>Slack is a communication and collaboration platform that organizes conversations into topics, groups or private messages.  Each topic or group is called a Channel.  Hack for LA uses slack to allow teams to connect, discuss and work on projects collectively.  There are channels set up for both specific projects, and specific functional roles.</p>
 
         
         <div class="guide-links">
           
-          <h2>In This Guide</h2>
-          <ul>
-            
-            <li><a href="#what-is-slack"> What is Slack? </a><br>
-              
-          </li>
-          
-            <li><a href="#when-to-use-reminders"> When to use Reminders </a><br>
-              
-              <ul style="padding-left: 20px;">
-                
-                <li><a href="#who-uses-reminders">Who uses reminders</a></li>
-                
-                <li><a href="#type-of-reminders">Type of Reminders</a></li>
-                
-            </ul>
-            
-          </li>
-          
-            <li><a href="#how-to-set-up-reminders-"> How to Set Up Reminders? </a><br>
-              
-              <ul style="padding-left: 20px;">
-                
-                <li><a href="#option-1-by-navigation">Option 1: by Navigation</a></li>
-                
-                <li><a href="#option-2-by-direct-entry">Option 2: by Direct Entry</a></li>
-                
-            </ul>
-            
-          </li>
-          
-            <li><a href="#when-to-use-reminders"> When to use Reminders </a><br>
-              
-          </li>
-          
-            <li><a href="#examples"> Examples </a><br>
-              
-          </li>
-          
-            <li><a href="#guide-authors"> Guide Authors </a><br>
-              
-          </li>
-          
-        </ul>
-        
       </div>
     </div>
     
@@ -207,10 +162,108 @@ If you are outside the Hack for LA community, please use this [feedback form](ht
       <h1>Guide Authors</h1>
       <p>Peer-created guides are an important part of Hack for LA's Culture.  They are created by our Volunteer Members based on effective processes developed on our projects.</p>
       <p>This guide was created and contributed to by:</p>
-      
-      <p><b>Help us make this guide better:</b></p>
 
-      
+      <div class="authors-container">
+          
+          <div class="authors-profile">
+            
+            <a href="https://github.com/mariastudnicka" target="_blank" title="Maria Studnicka's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/mariastudnicka" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/mariastudnicka" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Maria Studnicka</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/maria-studnicka/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/mariastudnicka" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://www.linkedin.com/in/katie-jensen/" target="_blank" title="Katie Jensen's LinkedIn Profile"><div class="author-img-placeholder"></div></a>
+            
+            <p>Katie Jensen</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/katie-jensen/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://github.com/SaashaG" target="_blank" title="Saasha Gilkes's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/SaashaG" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/SaashaG" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Saasha Gilkes</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/saashagilkes/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/SaashaG" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://github.com/Olivia-Chiong" target="_blank" title="Olivia Chiong's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/Olivia-Chiong" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/Olivia-Chiong" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Olivia Chiong</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/chiongolivia/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/Olivia-Chiong" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://github.com/alyssabenipayo" target="_blank" title="Alyssa Benipayo's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/alyssabenipayo" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/alyssabenipayo" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Alyssa Benipayo</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/alyssabenipayo/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/alyssabenipayo" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://github.com/SheIsBukki" target="_blank" title="Bukola Ogunleye's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/SheIsBukki" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/SheIsBukki" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Bukola Ogunleye</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/bukola-ogunleye-j/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/SheIsBukki" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+          <div class="authors-profile">
+            
+            <a href="https://github.com/ExperimentsInHonesty" target="_blank" title="Bonnie Wolfe's GitHub Profile"><img class="author-img" src="https://avatars.githubusercontent.com/ExperimentsInHonesty" width="100" height="100"/></a>
+            <!-- <img src="https://avatars.githubusercontent.com/ExperimentsInHonesty" alt="Author Image" width="100" height="100" border-radius="50%" > -->
+            
+            <p>Bonnie Wolfe</p>
+          </div>
+          <div class="authors-contact">
+          
+          <a href="https://www.linkedin.com/in/bonnieawolfe/" target="_blank" title="Linkedin Profile" class="fa fa-linkedin fa-xl"></a>
+          <a href="https://github.com/ExperimentsInHonesty" target="_blank" title="GitHub Profile" class="fa fa-github fa-xl"></a>
+          
+        </div>
+        
+      </div>
+
+      <p><b>Help us make this guide better:</b></p>
       <p>If you are a member of the Hack for LA community you can post any comments directly in the iterative version of this guide: <a href="https://www.google.com/"style="color: #fa114f;" >How to Set Reminders in Slack</a>.</p>
 
       <p>If you are outside the Hack for LA community, please use this feedback form to provide suggestions for improvement or how the guide is useful for you.</p>

--- a/css/style.css
+++ b/css/style.css
@@ -59,16 +59,17 @@ body {
 
 .page-content-container-grid {
 	display: grid;
-	grid-template-columns: auto;
+	grid-template-columns: 20vw auto;
 	grid-template-rows: auto;
 	grid-template-areas:
-		"content1 nav1"
-		"content2 nav2"
-		"content3 nav3"
-		"content4 nav4";
+		"content1 nav"
+		"content2 ......."
+		"content3 ......."
+		"content4 .......";
 	justify-content: start;
 	scroll-behavior: smooth;
 	align-items: start;
+	grid-column-start: 1;
 }
 
 .card-primary.page-card--guide.page-card--overview {
@@ -94,8 +95,45 @@ body {
 	grid-area: content2;
 }
 
+/* Guide Authors */
+
 .page-card--authors {
 	grid-area: content3;
+}
+
+.authors-container {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-gap: 20px;
+	margin-bottom: 32px;
+	margin-top: 20px;
+}
+
+.authors-profile {
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+}
+
+.authors-profile > a {
+	margin-right: 28px;
+}
+
+.authors-profile img {
+	border-radius: 50%;
+}
+
+.authors-contact {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.author-img-placeholder {
+	background-color: #efefef;
+	width: 100px;
+	height: 100px;
+	border-radius: 50%;
 }
 
 .card-primary {
@@ -127,7 +165,8 @@ body {
 }
 
 .sticky-nav {
-	grid-area: nav2;
+	grid-area: nav;
+	grid-column-start: 2;
 	display: none;
 	background: #fff;
 	border: 0px solid rgba(51, 51, 51, 0.06);
@@ -255,7 +294,6 @@ img {
 
 	.page-content-container-grid {
 		margin-left: 100px;
-		grid-area: content;
 		justify-self: start;
 		grid-template-columns: 996px auto;
 		grid-template-rows: auto;


### PR DESCRIPTION
Guide Authors now include the names, social media links (namely linkedin and github), and profile picture (taken from github only). Authors without github links will have a placeholder created with a div.

![screencapture-127-0-0-1-4000-guide-pages-how-to-set-reminders-in-slack-2022-02-13-02_07_58](https://user-images.githubusercontent.com/38295612/153748468-3c7a3ce1-2bca-4d82-aacd-a7b9a4614cdc.png)
 